### PR TITLE
chore: Go version update and addition of simple build test

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,0 +1,35 @@
+# This is a simple test action for the build test
+name: Build Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_test:
+    runs-on: ubuntu-2022
+    steps:
+      - name: Get Dependencies from apt
+        run: |
+          sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu gcc-mingw-w64
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "^1.21"
+
+      - name: Test
+        run: |
+          go test -v ./...
+
+      - name: Build
+        env:
+          CGO_ENABLED: 1
+          GOOS: linux
+          GOARCH: amd64
+        run: |
+          go build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kawana77b/bookmark
 
-go 1.20
+go 1.21
 
 require (
 	github.com/logrusorgru/aurora/v4 v4.0.0


### PR DESCRIPTION
This PR will update the Go version to 1.21.
Also, since build checks are required to use dependent packages and are cumbersome, we will add a simple test action.
The rest of my this is not the best, but I think it will help ease maintenance a bit.